### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/ubc/moodle-docker/security/code-scanning/1](https://github.com/ubc/moodle-docker/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define it at the workflow root (applies to all jobs unless overridden), immediately after the triggers and before `jobs:`. For this workflow, `contents: read` is the minimal and sufficient starting point for checkout/build/push-to-Docker-Hub behavior shown.

File to change:
- `.github/workflows/main.yml`  
Region:
- Between `workflow_dispatch:` and `jobs:`.

No imports, methods, or external definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
